### PR TITLE
`white-space: wrap` is not valid CSS

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -7,7 +7,6 @@ button {
   font-weight: 700;
   line-height: 48px;
   letter-spacing: 0.1px;
-  white-space: wrap;
   border-radius: 8px;
   cursor: pointer;
   color: #fff8f1;


### PR DESCRIPTION
according to https://validator.w3.org/, `wrap` is not a valid option for `white-space`.